### PR TITLE
FIX: Use `buildQuote` instead of `Quote.build`

### DIFF
--- a/javascripts/discourse/initializers/quick-quote-edits.js.es6
+++ b/javascripts/discourse/initializers/quick-quote-edits.js.es6
@@ -1,6 +1,6 @@
 import { withPluginApi } from 'discourse/lib/plugin-api';
 import Composer from "discourse/models/composer";
-import Quote from "discourse/lib/quote";
+import { buildQuote } from "discourse/lib/quote";
 
 export default {
   name: 'quick-quote-edits',
@@ -26,7 +26,7 @@ export default {
             if ((quoteState.buffer == "") || (quoteState.buffer == undefined)) {
               if (post) {
                if (((topic.highest_post_number + 1) - (post.post_number)) > settings.quick_quote_post_location_threshold) {
-                 quotedText = Quote.build(post, post.cooked);
+                 quotedText = buildQuote(post, post.cooked);
                  if (settings.quick_quote_remove_prior_quotes) {
                    quotedText = quotedText.replace(/<aside[\s\S]*<\/aside>/g, '');
                  };
@@ -55,7 +55,11 @@ export default {
             else
             {
               const quotedPost = postStream.findLoadedPost(quoteState.postId);
-              quotedText = Quote.build(quotedPost, quoteState.buffer);
+              quotedText = buildQuote(
+                quotedPost,
+                quoteState.buffer,
+                quoteState.opts
+              );
             };
 
             quoteState.clear();


### PR DESCRIPTION
Makes it work with the latest Discourse.

(issue reported in https://meta.discourse.org/t/quick-quote-theme-component/143621/4?u=cvx)